### PR TITLE
Run build during CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: actions/checkout@v2
       - run: yarn
       - run: yarn prettier:check
+      - run: yarn build


### PR DESCRIPTION
`build` will already get run by Zeit Now during deployment and errors will be surfaced there, but running `build` in the GitHub Actions workflow will allow both build and Prettier errors to be surfaced in the same place.